### PR TITLE
Use i18n for texts in Me Area version

### DIFF
--- a/generators/newwebapp/templates/uimodule/webapp/Component.js
+++ b/generators/newwebapp/templates/uimodule/webapp/Component.js
@@ -57,7 +57,7 @@ sap.ui.define([
 				oRenderer.addActionButton("sap.m.Button", {
 					id: "myHomeButton",
 					icon: "sap-icon://sys-help-2",
-					text: oResourceBundle.getText("buttonText"),
+					text: _oResourceBundle.getText("buttonText"),
 					press: function () {
 						MessageToast.show(_oResourceBundle.getText("msgMeAreaText"));
 					}
@@ -69,7 +69,7 @@ sap.ui.define([
 				oRenderer.addActionButton("sap.m.Button", {
 					id: "myAppButton",
 					icon: "sap-icon://sys-help",
-					text: oResourceBundle.getText("buttonText"),
+					text: _oResourceBundle.getText("buttonText"),
 					press: function () {
 						MessageToast.show(_oResourceBundle.getText("msgMeAreaTextApp"));
 					}

--- a/generators/newwebapp/templates/uimodule/webapp/Component.js
+++ b/generators/newwebapp/templates/uimodule/webapp/Component.js
@@ -14,6 +14,7 @@ sap.ui.define([
 
 		init: function () {
 			var rendererPromise = this._getRenderer();
+			var oResourceBundle = this.getModel("i18n").getResourceBundle();
 
 			// This is example code. Please replace with your implementation!
 <% if (features.includes("Add button to launchpad header")) { %>
@@ -52,12 +53,13 @@ sap.ui.define([
 			 * The first button is only visible if the Home page of SAP Fiori launchpad is open.
 			 */
 			rendererPromise.then(function (oRenderer) {
+				var _oResourceBundle = oResourceBundle;
 				oRenderer.addActionButton("sap.m.Button", {
 					id: "myHomeButton",
 					icon: "sap-icon://sys-help-2",
-					text: "Help for FLP page",
+					text: oResourceBundle.getText("buttonText"),
 					press: function () {
-						MessageToast.show("You pressed the button that opens a help page.");
+						MessageToast.show(_oResourceBundle.getText("msgMeAreaText"));
 					}
 				}, true, false, [sap.ushell.renderers.fiori2.RendererExtensions.LaunchpadState.Home]);
 
@@ -67,12 +69,12 @@ sap.ui.define([
 				oRenderer.addActionButton("sap.m.Button", {
 					id: "myAppButton",
 					icon: "sap-icon://sys-help",
-					text: "Help for App page",
+					text: oResourceBundle.getText("buttonText"),
 					press: function () {
-						MessageToast.show("You pressed the button that opens a help for apps page.");
+						MessageToast.show(_oResourceBundle.getText("msgMeAreaTextApp"));
 					}
 				}, true, false, [sap.ushell.renderers.fiori2.RendererExtensions.LaunchpadState.App]);
-			});
+			}.bind(this));
 <% } %>
 		},
 

--- a/generators/newwebapp/templates/uimodule/webapp/i18n/i18n.properties
+++ b/generators/newwebapp/templates/uimodule/webapp/i18n/i18n.properties
@@ -1,2 +1,5 @@
 pluginTitle=<%=projectname%>
 pluginDescription=<%=projectname%>
+buttonText=Help for FLP page
+msgMeAreaText=You pressed the button that opens a help page.
+msgMeAreaTextApp=You pressed the button that opens a help for apps page.

--- a/generators/newwebapp/templates/uimodule/webapp/i18n/i18n_en.properties
+++ b/generators/newwebapp/templates/uimodule/webapp/i18n/i18n_en.properties
@@ -1,2 +1,5 @@
 pluginTitle=<%=projectname%>
 pluginDescription=<%=projectname%>
+buttonText=Help for FLP page
+msgMeAreaText=You pressed the button that opens a help page.
+msgMeAreaTextApp=You pressed the button that opens a help for apps page.

--- a/generators/newwebapp/templates/uimodule/webapp/i18n/i18n_en_US.properties
+++ b/generators/newwebapp/templates/uimodule/webapp/i18n/i18n_en_US.properties
@@ -1,2 +1,5 @@
 pluginTitle=<%=projectname%>
 pluginDescription=<%=projectname%>
+buttonText=Help for FLP page
+msgMeAreaText=You pressed the button that opens a help page.
+msgMeAreaTextApp=You pressed the button that opens a help for apps page.

--- a/generators/newwebapp/templates/uimodule/webapp/manifest.json
+++ b/generators/newwebapp/templates/uimodule/webapp/manifest.json
@@ -39,6 +39,14 @@
 			"compact": true,
 			"cozy": false
 		},
+		"models": {
+		    "i18n": {
+			"type": "sap.ui.model.resource.ResourceModel",
+			"settings": {
+			    "bundleName": "<%=appId%>.i18n.i18n"
+			}
+		    }
+		},
 		"dependencies": {
 			"minUI5Version": "1.38.1",
 			"libs": {


### PR DESCRIPTION
The texts of the FLP plugin are hard coded to english in Component.js. The code changes here is adding the i18n model and reads the texts to display from the model.

This is now only for the Me Area version / template of the plugin. The text of the button in the me area menu as well as the text in the message toast are moved to i18n and read from there. This introduces the i18n properties buttonText, msgMeAreaText and msgMeAreaTextApp.

I hope this makes the plugin easier to use and adjust for devs that have to provide the texts in different languages.